### PR TITLE
feishu-portable: disable browser sandbox

### DIFF
--- a/x86_64/feishu-portable/PKGBUILD
+++ b/x86_64/feishu-portable/PKGBUILD
@@ -6,7 +6,7 @@ pkgname=feishu-portable
 pkgver=7.54.11
 _pkghash_x64=f2c1bb9d
 _pkghash_arm64=0940b960
-pkgrel=1
+pkgrel=2
 epoch=1
 pkgdesc="Linux client of Feishu (Lark) from Bytedance. Sandboxed by portable."
 arch=('x86_64' 'aarch64')
@@ -23,13 +23,11 @@ source=(
     com.bytedance.feishu.desktop
     feishu.sh
 )
+sha256sums=('38dede3b40110c7d1018301e001c64b9cf8d725303678d69ab39d4ba7c118631'
+            '6c96e320a3203642798d4e52262c01740e8adcd5f7bc613b5bfa2c13b9cb9606'
+            'c445a576126f6a7b33e9a35b472d33bcb7d2e56bcf2c99de7551b8c48bb52f8d')
 sha256sums_x86_64=('ee1dc43e90fa3e5c252326b1c991d8cf7ae9b98f1f8b92bc600a37567df4d2a4')
 sha256sums_aarch64=('5348218e5f8119eaf1ee1c953e71c729eaa2ab53927cabf8ccf87454e9128fe2')
-sha256sums=(
-    'c41a282c27ceaef2c86c66f9207da9d0c1b0250735ed36dccb78ae81e484384f'
-    '6c96e320a3203642798d4e52262c01740e8adcd5f7bc613b5bfa2c13b9cb9606'
-    'c445a576126f6a7b33e9a35b472d33bcb7d2e56bcf2c99de7551b8c48bb52f8d'
-)
 
 function package() {
     depends+=(ca-certificates gtk3 nss xdg-utils dnsmasq portable libmfx libpulse alsa-lib xwaylandvideobridge)

--- a/x86_64/feishu-portable/portable-config
+++ b/x86_64/feishu-portable/portable-config
@@ -10,7 +10,7 @@ friendlyName="Feishu"
 stateDirectory="Feishu_Data"
 
 # This is the target executable to launch
-launchTarget="env -u WAYLAND_DISPLAY /opt/bytedance/feishu/bytedance-feishu --enable-features=VaapiVideoDecodeLinuxGL,VaapiVideoDecoder,TouchpadOverscrollHistoryNavigation --no-suid-sandbox"
+launchTarget="env -u WAYLAND_DISPLAY /opt/bytedance/feishu/bytedance-feishu --enable-features=VaapiVideoDecodeLinuxGL,VaapiVideoDecoder,TouchpadOverscrollHistoryNavigation --no-sandbox"
 
 # Takes boolean value. When enabled, do not process XAuth files and enable X access. Generally this should be always false.
 waylandOnly=false


### PR DESCRIPTION
This prevents feishu from creating it's own sandboxes, which may affect how host services identify it's processes.