### PR TITLE
WPS: add stashpak configuration

### DIFF
--- a/x86_64/wps-office-365-portable/stashpak.toml
+++ b/x86_64/wps-office-365-portable/stashpak.toml
@@ -1,0 +1,25 @@
+[metadata]
+# Optional
+# The command to build a package. Should be "extra-x86_64-build" or "archlinuxcn-x86_64-build"
+buildPrefix	= "extra-x86_64-build"
+
+# Your GitHub user name
+maintainer	= "sf467"
+
+[[depends]]
+# Optional
+#buildPrefix	= "extra-x86_64-build"
+
+# The package name of a dependency
+pkgname		= "portable"
+
+# Source can be either a string of git URL (type git), or repo name (type repo) to download from locally defined repositories.
+sourceType	= "repo"
+source		= "archlinuxcn"
+
+[[depends]]
+# Optional
+#buildPrefix	= "extra-x86_64-build"
+pkgname		= "wps-office-365"
+sourceType	= "git"
+source		= "https://aur.archlinux.org/wps-office-365.git"


### PR DESCRIPTION
To test:

Install stashpak version `[0.2.2](https://github.com/Kimiblock/stashpak/releases/tag/0.2.2)`.

Chdir to the WPS directory, and run `stashpak install-local`