### PR TITLE
feishu-portable: 7.66.11

### DIFF
--- a/x86_64/feishu-portable/.SRCINFO
+++ b/x86_64/feishu-portable/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = feishu-portable
 	pkgdesc = Linux client of Feishu (Lark) from Bytedance. Sandboxed by portable.
-	pkgver = 7.62.9
+	pkgver = 7.66.11
 	pkgrel = 1
 	epoch = 1
 	url = https://www.feishu.cn/
@@ -20,10 +20,10 @@ pkgbase = feishu-portable
 	source = com.bytedance.feishu.desktop
 	sha256sums = 1c860975bdafada97b15a8ed358dbf1e7199feb300d5b6419a25046cd92628d4
 	sha256sums = SKIP
-	source_x86_64 = https://sf3-cn.feishucdn.com/obj/ee-appcenter/f63223d9/Feishu-linux_x64-7.62.9.deb
-	sha256sums_x86_64 = f7a84e6002ac7ca699b6fbfe8e734290579e095bb0b9077048748f8390069883
-	source_aarch64 = https://sf3-cn.feishucdn.com/obj/ee-appcenter/d95df105/Feishu-linux_arm64-7.62.9.deb
-	sha256sums_aarch64 = 8fe7c4b4977e8da1d5dcd07e31783c6a792ce85ddc77c57f4f3d8f707310b76a
+	source_x86_64 = https://sf3-cn.feishucdn.com/obj/ee-appcenter/6e3610b5/Feishu-linux_x64-7.66.11.deb
+	sha256sums_x86_64 = dc4f0d2c2db3cc83bb9758cf71e3e131f09a7e08eec963b378d660c534ccfd31
+	source_aarch64 = https://sf3-cn.feishucdn.com/obj/ee-appcenter/36c6e858/Feishu-linux_arm64-7.66.11.deb
+	sha256sums_aarch64 = da73070ae272d9d622a24c11ddd1409084de0601fc2bda6827d82424da78d9a4
 
 pkgname = feishu-portable
 	depends = ca-certificates
@@ -35,4 +35,3 @@ pkgname = feishu-portable
 	depends = libmfx
 	depends = libpulse
 	depends = alsa-lib
-	depends = xwaylandvideobridge

--- a/x86_64/feishu-portable/PKGBUILD
+++ b/x86_64/feishu-portable/PKGBUILD
@@ -3,9 +3,9 @@
 # https://github.com/TD-Sky/PKGBUILDs
 
 pkgname=feishu-portable
-pkgver=7.62.9
-_pkghash_x64=f63223d9
-_pkghash_arm64=d95df105
+pkgver=7.66.11
+_pkghash_x64=6e3610b5
+_pkghash_arm64=36c6e858
 pkgrel=1
 epoch=1
 pkgdesc="Linux client of Feishu (Lark) from Bytedance. Sandboxed by portable."
@@ -24,11 +24,11 @@ source=(
 )
 sha256sums=('1c860975bdafada97b15a8ed358dbf1e7199feb300d5b6419a25046cd92628d4'
             'SKIP')
-sha256sums_x86_64=('f7a84e6002ac7ca699b6fbfe8e734290579e095bb0b9077048748f8390069883')
-sha256sums_aarch64=('8fe7c4b4977e8da1d5dcd07e31783c6a792ce85ddc77c57f4f3d8f707310b76a')
+sha256sums_x86_64=('dc4f0d2c2db3cc83bb9758cf71e3e131f09a7e08eec963b378d660c534ccfd31')
+sha256sums_aarch64=('da73070ae272d9d622a24c11ddd1409084de0601fc2bda6827d82424da78d9a4')
 
 function package() {
-    depends+=(ca-certificates gtk3 nss xdg-utils dnsmasq portable libmfx libpulse alsa-lib xwaylandvideobridge)
+    depends+=(ca-certificates gtk3 nss xdg-utils dnsmasq portable libmfx libpulse alsa-lib)
 
     tar -xpvf "${srcdir}/data.tar.xz" --xattrs-include='*' --numeric-owner -C "${pkgdir}"
 

--- a/x86_64/feishu-portable/stashpak.toml
+++ b/x86_64/feishu-portable/stashpak.toml
@@ -27,9 +27,3 @@ pkgname		= "portable-packer"
 # Source can be either a string of git URL (type git), or repo name (type repo) to download from locally defined repositories.
 sourceType	= "repo"
 source		= "archlinuxcn"
-
-[[depends]]
-pkgname		= "xwaylandvideobridge"
-sourceType	= "git"
-source		= "https://aur.archlinux.org/xwaylandvideobridge.git"
-install		= true


### PR DESCRIPTION
1. Remove `xwaylandbridge` because it always doesn't work. Users should try other screen capture approach such as `obs`.
2. I met `desktop file validation failed` at `stashpak install-local`.